### PR TITLE
feat(auth): Implement Session Persistence and Fix Routing Loop

### DIFF
--- a/src/contexts/AuthContext.tsx
+++ b/src/contexts/AuthContext.tsx
@@ -1,4 +1,5 @@
-import { createContext, useState, useContext, type ReactNode } from 'react';
+// Adicione o 'useEffect' aos seus imports do React
+import { createContext, useState, useContext, type ReactNode, useEffect } from 'react';
 import {
   login as loginService,
   register as registerService,
@@ -28,7 +29,6 @@ interface AuthContextType {
   logout: () => void;
 }
 
-// --- Contexto ---
 const AuthContext = createContext<AuthContextType | null>(null);
 
 // eslint-disable-next-line react-refresh/only-export-components
@@ -40,13 +40,26 @@ export const useAuth = () => {
   return context;
 };
 
-// --- Provedor ---
 interface AuthProviderProps {
   children: ReactNode;
 }
 
 export const AuthProvider = ({ children }: AuthProviderProps) => {
   const [user, setUser] = useState<User | null>(null);
+
+  useEffect(() => {
+    const checkAuthStatus = async () => {
+      try {
+        const userProfile = await getProfile();
+        setUser(userProfile);
+      } catch (error) {
+        console.error("No active session found.", error);
+        setUser(null);
+      }
+    };
+
+    checkAuthStatus();
+  }, []);
 
   const handleSuccessfulAuth = async () => {
     try {
@@ -60,7 +73,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
 
   const register = async (userData: RegisterData) => {
     await registerService(userData);
-    // Após o registro, faz o login automaticamente para obter o cookie e buscar o perfil
     await login({ email: userData.email, password: userData.password });
   };
 
@@ -75,7 +87,6 @@ export const AuthProvider = ({ children }: AuthProviderProps) => {
     } catch(error) {
       console.error("Logout API call failed", error);
     } finally {
-      // Limpa o estado do usuário independentemente do sucesso da chamada da API
       setUser(null);
     }
   };

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -8,8 +8,9 @@ import { PublicRoute } from './PublicRoute';
 export const AppRoutes = () => {
   return (
     <Routes>
+      <Route path="/" element={<HomePage />} />
+
       <Route element={<PublicRoute />}>
-        <Route path="/" element={<HomePage />} />
         <Route path="/register" element={<SignUpPage />} />
         <Route path="/login" element={<LoginPage />} />
       </Route>


### PR DESCRIPTION
### Description

This PR introduces two key improvements to the authentication flow and user experience:

1.  **Session Persistence**: Users now remain logged in even after closing and reopening the browser.
2.  **Routing Fix**: A bug that caused a blank screen (infinite redirect loop) for logged-in users on the homepage has been resolved.

### Changes Made

-   **`AuthContext.tsx`**: An `useEffect` hook has been added to run on application startup. It calls the `getProfile()` service to check for an active user session (via the `accessToken` cookie) and updates the global authentication state accordingly.
-   **`AppRoutes.tsx`**: The route structure has been refactored. The `HomePage` route (`/`) was moved outside of the `PublicRoute` to prevent the redirect loop. The `PublicRoute` now correctly wraps only the routes that should be accessible to unauthenticated users (e.g., `/login`, `/register`).

### How to Test

1.  **Verify Session Persistence:**
    -   Log in to the application.
    -   Confirm you are redirected to the homepage and your user information appears in the header.
    -   Close the browser tab or the entire browser.
    -   Reopen the application URL.
    -   **Expected Result:** You should still be logged in and see the homepage directly, without being prompted to log in again.

2.  **Verify Routing Fix:**
    -   While logged in, try to navigate manually to `/login`.
    -   **Expected Result:** You should be redirected back to the homepage (`/`).
    -   Log out.
    -   Navigate to `/login` again.
    -   **Expected Result:** The login page should now be displayed correctly.