### PR TITLE
feat(client): Add frontend testing structure and initial tests

### DIFF
--- a/src/layouts/Footer/__tests__/Footer.test.tsx
+++ b/src/layouts/Footer/__tests__/Footer.test.tsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect } from 'vitest';
+import { Footer } from '../Footer';
+
+describe('Footer', () => {
+  it('should render footer sections and social media icons', () => {
+    render(<Footer />);
+
+    expect(screen.getByText('Colophon')).toBeInTheDocument();
+
+    expect(screen.getByText('Features')).toBeInTheDocument();
+    expect(screen.getByText('Support')).toBeInTheDocument();
+    expect(screen.getByText('Social Medias')).toBeInTheDocument();
+
+    expect(
+      screen.getByText(/© 2025 colophon\. all rights reserved\./i)
+    ).toBeInTheDocument();
+  });
+});

--- a/src/pages/HomePage/__tests__/HomePage.test.tsx
+++ b/src/pages/HomePage/__tests__/HomePage.test.tsx
@@ -1,0 +1,45 @@
+import { render, screen } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { HomePage } from '../HomePage';
+import { BrowserRouter } from 'react-router-dom';
+import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useAuthMock = useAuth as Mock;
+
+describe('HomePage', () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthMock.mockReturnValue({
+      user: null,
+    });
+  });
+
+  it('should render the main heading and key sections', () => {
+    render(
+      <BrowserRouter>
+        <AuthProvider>
+          <HomePage />
+        </AuthProvider>
+      </BrowserRouter>
+    );
+
+    expect(
+      screen.getByRole('heading', {
+        name: /organize your personal library/i,
+      })
+    ).toBeInTheDocument();
+
+    expect(screen.getByAltText('Illuminated Bookshelves')).toBeInTheDocument();
+
+    expect(
+      screen.getByRole('heading', { name: /why choose colophon\?/i })
+    ).toBeInTheDocument();
+
+    expect(screen.getByText('Advanced Searching')).toBeInTheDocument();
+  });
+});

--- a/src/pages/LoginPage/__tests__/LoginPage.test.tsx
+++ b/src/pages/LoginPage/__tests__/LoginPage.test.tsx
@@ -1,0 +1,80 @@
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { LoginPage } from '../LoginPage';
+import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+import { BrowserRouter } from 'react-router-dom';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useAuthMock = useAuth as Mock;
+
+describe('LoginPage', () => {
+  const loginMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthMock.mockReturnValue({
+      login: loginMock,
+      user: null,
+    });
+  });
+
+  it('should render the login form and allow user to type', async () => {
+    render(
+      <BrowserRouter>
+        <AuthProvider>
+          <LoginPage />
+        </AuthProvider>
+      </BrowserRouter>
+    );
+
+    const emailInput = screen.getByPlaceholderText('Insert your email here');
+    const passwordInput = screen.getByPlaceholderText(
+      'Insert your password here'
+    );
+
+    expect(emailInput).toBeInTheDocument();
+    expect(passwordInput).toBeInTheDocument();
+
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+
+    expect(emailInput).toHaveValue('test@example.com');
+    expect(passwordInput).toHaveValue('password123');
+  });
+
+  it('should call login function on form submission', async () => {
+    render(
+      <BrowserRouter>
+        <AuthProvider>
+          <LoginPage />
+        </AuthProvider>
+      </BrowserRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    });
+
+    const main = screen.getByRole('main');
+
+    const submitButton = within(main).getByRole('button', {
+      name: /login/i,
+    });
+
+    fireEvent.click(submitButton);
+
+    await waitFor(() => {
+      expect(loginMock).toHaveBeenCalledWith({
+        email: 'test@example.com',
+        password: 'password123',
+      });
+    });
+  });
+});

--- a/src/pages/SignUpPage/__tests__/SignUpPage.test.tsx
+++ b/src/pages/SignUpPage/__tests__/SignUpPage.test.tsx
@@ -1,0 +1,83 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { describe, it, expect, vi, beforeEach, type Mock } from 'vitest';
+import { SignUpPage } from '../SignUpPage';
+import { AuthProvider, useAuth } from '@/contexts/AuthContext';
+import { BrowserRouter } from 'react-router-dom';
+
+vi.mock('@/contexts/AuthContext', () => ({
+  useAuth: vi.fn(),
+  AuthProvider: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+}));
+
+const useAuthMock = useAuth as Mock;
+
+describe('SignUpPage', () => {
+  const registerMock = vi.fn();
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    useAuthMock.mockReturnValue({
+      register: registerMock,
+    });
+  });
+
+  it('should render the sign up form and allow user to type', () => {
+    render(
+      <BrowserRouter>
+        <AuthProvider>
+          <SignUpPage />
+        </AuthProvider>
+      </BrowserRouter>
+    );
+
+    const nameInput = screen.getByPlaceholderText('Insert your name here');
+    const emailInput = screen.getByPlaceholderText('Insert your email here');
+    const passwordInput = screen.getByLabelText('Password');
+    const confirmPasswordInput = screen.getByLabelText('Confirm Password');
+
+    fireEvent.change(nameInput, { target: { value: 'Test User' } });
+    fireEvent.change(emailInput, { target: { value: 'test@example.com' } });
+    fireEvent.change(passwordInput, { target: { value: 'password123' } });
+    fireEvent.change(confirmPasswordInput, {
+      target: { value: 'password123' },
+    });
+
+    expect(nameInput).toHaveValue('Test User');
+    expect(emailInput).toHaveValue('test@example.com');
+    expect(passwordInput).toHaveValue('password123');
+    expect(confirmPasswordInput).toHaveValue('password123');
+  });
+
+  it('should call register function on form submission', async () => {
+    render(
+      <BrowserRouter>
+        <AuthProvider>
+          <SignUpPage />
+        </AuthProvider>
+      </BrowserRouter>
+    );
+
+    fireEvent.change(screen.getByLabelText('Name'), {
+      target: { value: 'Test User' },
+    });
+    fireEvent.change(screen.getByLabelText('Email'), {
+      target: { value: 'test@example.com' },
+    });
+    fireEvent.change(screen.getByLabelText('Password'), {
+      target: { value: 'password123' },
+    });
+    fireEvent.change(screen.getByLabelText('Confirm Password'), {
+      target: { value: 'password123' },
+    });
+
+    fireEvent.click(screen.getByRole('button', { name: /sign up/i }));
+
+    await waitFor(() => {
+      expect(registerMock).toHaveBeenCalledWith({
+        name: 'Test User',
+        email: 'test@example.com',
+        password: 'password123',
+      });
+    });
+  });
+});


### PR DESCRIPTION
## Description

This PR introduces the testing structure for the client application (`colophon-client`) using Vitest and React Testing Library. The goal is to establish a solid foundation for code quality, prevent regressions, and ensure components behave as expected.

Initial tests have been added for the following components and pages:
- `HomePage`
- `LoginPage`
- `SignUpPage`
- `Footer`

## Changes Made

- **Vitest Configuration**: `vite.config.ts` and `setupTests.ts` have been configured for the test environment.
- **Page Tests**: Added tests that simulate user interaction, such as filling out forms and clicking buttons on the Login and Sign Up pages.
- **Component Tests**: Added rendering tests to ensure the `HomePage` and `Footer` components display static content correctly.
- **Mocks**: Implemented a mock for the `AuthContext` to isolate components that depend on authentication state, allowing for consistent and independent tests.

## How to Test

1.  Clone this branch.
2.  Navigate to the `colophon-client` directory.
3.  Install dependencies with `npm install`.
4.  Run the test suite with `npm test`.
5.  All 6 tests should pass successfully.

With this foundation, we can easily add more tests for new features in the future.