### PR TITLE
feat(search): Implement auto-search for explore button

### DIFF
--- a/src/pages/HomePage/HomePage.tsx
+++ b/src/pages/HomePage/HomePage.tsx
@@ -24,7 +24,7 @@ export const HomePage = () => {
             <Link to="/register"  className="flex justify-center items-center h-10 px-2 py-4 rounded-md text-sm font-semibold cursor-pointer transition bg-primary w-full sm:w-max rounded-xl px-8 text-white hover:bg-terracotta/90 transform hover:scale-105 transition-all duration-200 shadow-lg">
               Start Now
             </Link>
-            <Link to="/" className="flex justify-center items-center h-10 py-4 text-sm font-semibold cursor-pointer w-full sm:w-max rounded-xl border-2 hover:bg-highlight border-highlight text-highlight hover:text-white px-8 transition-all duration-200">
+            <Link to="/books?q=discover" className="flex justify-center items-center h-10 py-4 text-sm font-semibold cursor-pointer w-full sm:w-max rounded-xl border-2 hover:bg-highlight border-highlight text-highlight hover:text-white px-8 transition-all duration-200">
               Explore
             </Link>
           </div>

--- a/src/pages/SearchPage/SearchPage.tsx
+++ b/src/pages/SearchPage/SearchPage.tsx
@@ -5,7 +5,8 @@ import { MainLayout } from '@/layouts/MainLayout/MainLayout';
 import { searchBooks } from '@/services/book.service';
 import type { Book } from '@/types';
 import { isAxiosError } from 'axios';
-import { useState } from 'react';
+import { useState, useEffect, useCallback } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { HiOutlineMagnifyingGlass } from 'react-icons/hi2';
 import Select, { type MultiValue, type StylesConfig } from 'react-select';
 
@@ -102,9 +103,10 @@ export const SearchPage = () => {
   const [hasSearched, setHasSearched] = useState(false);
   const [selectedGenres, setSelectedGenres] = useState<MultiValue<GenreOption>>([]);
 
-  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
-    event.preventDefault();
-    if (!search) {
+  const [searchParams] = useSearchParams();
+
+  const performSearch = useCallback(async (query: string) => {
+    if (!query) {
       setBooks([]);
       setError('Please type something to search.');
       return;
@@ -117,7 +119,7 @@ export const SearchPage = () => {
     setSelectedGenres([]);
 
     try {
-      const foundBooks = await searchBooks(search);
+      const foundBooks = await searchBooks(query);
       setBooks(foundBooks);
     } catch (err) {
       let errorMessage = 'An unexpected error occurred. Please try again.';
@@ -130,7 +132,21 @@ export const SearchPage = () => {
     } finally {
       setIsLoading(false);
     }
+  }, []);
+
+  const handleSubmit = async (event: React.FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    performSearch(search);
   };
+
+  useEffect(() => {
+    const exploreQuery = searchParams.get('q');
+    if (exploreQuery === 'discover') {
+      const defaultQuery = 'Classic Literature';
+      setSearch(defaultQuery);
+      performSearch(defaultQuery);
+    }
+  }, [searchParams, performSearch]);
 
   const filteredBooks = books.filter((bookObject) => {
     if (selectedGenres.length === 0) {


### PR DESCRIPTION
### Summary

This PR introduces an enhancement to the user experience by transforming the "Explore" button on the HomePage into an instant discovery feature. When a user clicks this button, they are now taken to the Search page where a default search is automatically performed, immediately showing them relevant content.

### Changes

-   **HomePage**: The "Explore" button's `Link` component now navigates to `/books?q=discover`.
-   **SearchPage**:
    -   Implemented `useSearchParams` to detect the `q=discover` query parameter upon page load.
    -   Added a `useEffect` hook that triggers a search for "Classic Literature" if the parameter is present.
    -   Refactored the core search logic into a stable function using the `useCallback` hook. This prevents unnecessary re-renders and satisfies the `exhaustive-deps` ESLint rule, ensuring the `useEffect` hook is safe and efficient.